### PR TITLE
Removing installationDirectory option from the frontend plugin config

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,5 +1,4 @@
 {
-  "cwd": ".",
   "directory": "target/bower_components",
   "color": true,
   "save": true,

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
 node_modules
+node

--- a/pom.xml
+++ b/pom.xml
@@ -73,9 +73,9 @@
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
                 <version>1.3</version>
-                <configuration>
+                <!--configuration>
                     <installDirectory>${project.build.directory}</installDirectory>
-                </configuration>
+                </configuration-->
                 <executions>
                     <execution>
                         <!-- optional: you don't really need execution ids, but it looks nice in your build log. -->


### PR DESCRIPTION
@jamesward : I think the installationDirectory option confuses the frontend plugin. I've removed it, along with the bower working dir.